### PR TITLE
Dependencies updated + UTF-8 encoding by default.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,12 @@
 
     <groupId>Referral</groupId>
     <artifactId>Referral</artifactId>
-    <version>2.2.4</version>
+    <version>2.2.5</version>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    </properties>
 
     <repositories>
         <repository>
@@ -59,15 +64,14 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.14.4-R0.1-SNAPSHOT</version>
+            <version>1.21.5-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>me.clip</groupId>
             <artifactId>placeholderapi</artifactId>
-            <version>2.10.10</version>
+            <version>2.11.6</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>
-
 </project>

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: Referral
-version: 2.2.4
+version: 2.2.5
 api-version: 1.13
 author: Teenaapje
 main: Me.Teenaapje.Referral.ReferralCore


### PR DESCRIPTION
Update of the dependencies, and a warning that would pop-up with every Maven build for default encoding.